### PR TITLE
Use environment variables with two email addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ A simple application that selects a random commit for code review.
 The application looks to the following environment variables for its configuration:
 
 * `ODDS` - A string of the format "x:y" that describes the likelihood that a commit will be selected for review (e.g. "1:25").
-* `REVIEWERS` - A comma-separated list of e-mail addresses that code reviews may be addressed to.
+* `REVIEWERS` - A comma-separated list of e-mail address pairs (first and second in pair separated by a colon) that code reviews
+  may be addressed to. **Example:** "user1@personal.com:user1@work.com,user2@personal.com:user2@work.com,..."
 * `SMTP_HOST` - A string describing the SMTP host.
 * `SMTP_PORT` - A string describing the SMTP port.
 * `SMTP_DOMAIN` - A string describing the SMTP domain.

--- a/lib/application.rb
+++ b/lib/application.rb
@@ -7,7 +7,15 @@ configure do
   set :odds, ENV["ODDS"]
 
   # A list of strings describing e-mail addresses a code review may be addressed to.
-  set :reviewers, ENV["REVIEWERS"].split(",")
+
+  raw_reviewers = ENV["REVIEWERS"].split(",")
+  reviewers = []
+  raw_reviewers.each do |reviewer|
+    personal, work = reviewer.split(":")
+    reviewers << { personal: personal, work: work }
+  end
+
+  set :reviewers, reviewers
 end
 
 Pony.options = {
@@ -32,7 +40,7 @@ post "/" do
     if rand(100) <= chance
 
       reviewers = settings.reviewers.reject do |reviewer|
-        reviewer == commit["author"]["email"]
+        reviewer.has_value? commit["author"]["email"]
       end
 
       reviewer = reviewers.sample
@@ -40,7 +48,7 @@ post "/" do
       if reviewer
 
         Pony.mail({
-          to: reviewer,
+          to: reviewer[:work],
           from: "Hyper <no-reply@hyper.no>",
           subject: "You've been selected to review #{commit["author"]["name"]}'s commit",
           body: erb(:reviewer_email, locals: {

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,7 +6,7 @@ Coveralls.wear!
 
 ENV["RACK_ENV"]   = "test"
 ENV["ODDS"]       = "1:1"
-ENV["REVIEWERS"] = "johannes@hyper.no,espen@hyper.no,tim@hyper.no"
+ENV["REVIEWERS"] = "johannes@gmail.com:johannes@hyper.no,tim@gmail.com:tim@hyper.no,espen@gmail.com:espen@hyper.no"
 
 require "application"
 require "odds"


### PR DESCRIPTION
This is another attempt at fixing #1.

To support reviewers with a different Git-configured e-mail address and code
review addresses, the environment variable REVIEWERS must be adjusted to store
both of these addresses per reviewer.

NB: As this commit makes use of the new structure, it breaks the previous setup.
